### PR TITLE
docs: clarify repo owner placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Commands live under `base/.gemini/commands` and can be installed to your environ
 
 ### Linux / macOS
 ```bash
-curl -fsSL https://raw.githubusercontent.com/USER/gcliplugins/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/<owner>/gcliplugins/main/install.sh | bash
 ```
+Replace `<owner>` with the GitHub username or organization that owns this repository.
 
 ### Windows (PowerShell)
 ```powershell
-iwr https://raw.githubusercontent.com/USER/gcliplugins/main/install.ps1 -useb | iex
+iwr https://raw.githubusercontent.com/<owner>/gcliplugins/main/install.ps1 -useb | iex
 ```
+Replace `<owner>` with the repository owner's GitHub username or organization.
 
 ## Base Commands
 A brief summary of the included slash commands:

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$repo = "https://github.com/USER/gcliplugins"
+$repo = "https://github.com/<owner>/gcliplugins" # Replace <owner> with the repository owner's GitHub username or organization
 $temp = New-TemporaryFile
 Remove-Item $temp
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-REPO="https://github.com/USER/gcliplugins"
+REPO="https://github.com/<owner>/gcliplugins" # Replace <owner> with the repository owner's GitHub username or organization
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
 git clone --depth 1 "$REPO" "$TEMP_DIR" >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- clarify install instructions to use <owner> placeholder and explain substitution
- align shell and PowerShell install scripts with same repository URL placeholder

## Testing
- `bash -n install.sh`
- (fails: `pwsh`: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68b1c26a057483208a17c261c4fd712e