### PR TITLE
docs: add detailed instructions for commands

### DIFF
--- a/docs/commands/cleanproject.md
+++ b/docs/commands/cleanproject.md
@@ -1,11 +1,14 @@
-
 # /cleanproject
 
-Remove debug artifacts with git safety.
+Remove debug artifacts and temporary files using git-safe methods.
 
 **Usage**:
 ```
 /cleanproject
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Scan the repository for build outputs, logs, and other non-source files.
+- Use git-aware commands such as `git clean` to delete only untracked artifacts.
+- Avoid removing tracked files or configuration that may be required.
+- Summarize what was removed and confirm the working tree is clean.

--- a/docs/commands/commit.md
+++ b/docs/commands/commit.md
@@ -1,4 +1,3 @@
-
 # /commit
 
 Conventional commits with context analysis.
@@ -8,4 +7,8 @@ Conventional commits with context analysis.
 /commit
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Review staged changes with `git status` and `git diff --staged`.
+- Craft a conventional commit message summarizing the changes.
+- Keep the subject line under 72 characters and add a body when helpful.
+- Execute the commit and report the resulting hash.

--- a/docs/commands/contributing.md
+++ b/docs/commands/contributing.md
@@ -1,11 +1,14 @@
-
 # /contributing
 
-Check CONTRIBUTING readiness; propose updates.
+Create or update repository contribution guidelines.
 
 **Usage**:
 ```
 /contributing
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Check for an existing `CONTRIBUTING.md` file.
+- If missing, create one outlining how to file issues and submit pull requests.
+- If present, update it with any new project-specific conventions.
+- Keep the guidance clear and concise.

--- a/docs/commands/create-todos.md
+++ b/docs/commands/create-todos.md
@@ -1,11 +1,14 @@
-
 # /create-todos
 
-Insert contextual TODOs for clear follow-ups.
+Insert TODO comments for follow-up work.
 
 **Usage**:
 ```
 /create-todos
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Identify areas that need future improvements or fixes.
+- Add TODO comments using a consistent format (e.g., `TODO: description`).
+- Place comments near the relevant code blocks.
+- Keep each TODO focused and actionable.

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -1,11 +1,14 @@
-
 # /docs
 
-Curate and update project docs.
+Improve or create project documentation.
 
 **Usage**:
 ```
 /docs
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Locate documentation that is missing, outdated, or unclear.
+- Update existing docs or add new files to explain current behavior.
+- Use clear language and examples where helpful.
+- Ensure links and references are accurate.

--- a/docs/commands/explain-like-senior.md
+++ b/docs/commands/explain-like-senior.md
@@ -1,11 +1,14 @@
-
 # /explain-like-senior
 
-Senior-level explanations with context.
+Explain code as a senior engineer would.
 
 **Usage**:
 ```
 /explain-like-senior
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Provide a high-level summary of the selected code.
+- Describe design decisions and potential trade-offs.
+- Highlight edge cases or pitfalls a junior developer should know.
+- Keep the explanation concise yet informative.

--- a/docs/commands/find-todos.md
+++ b/docs/commands/find-todos.md
@@ -1,11 +1,14 @@
-
 # /find-todos
 
-Extract and group TODOs.
+Locate TODO comments in the codebase.
 
 **Usage**:
 ```
 /find-todos
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Search the repository for `TODO` markers.
+- For each TODO, report the file path and line number.
+- Provide a brief snippet of context for each result.
+- If no TODOs are found, state that explicitly.

--- a/docs/commands/fix-imports.md
+++ b/docs/commands/fix-imports.md
@@ -1,11 +1,14 @@
-
 # /fix-imports
 
-Normalize/repair imports after changes.
+Organize and deduplicate import statements.
 
 **Usage**:
 ```
 /fix-imports
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Scan files for unused or duplicate imports.
+- Remove unused imports and group the remaining ones logically.
+- Sort imports alphabetically or per project conventions.
+- Ensure code still compiles or runs after changes.

--- a/docs/commands/fix-todos.md
+++ b/docs/commands/fix-todos.md
@@ -1,11 +1,14 @@
-
 # /fix-todos
 
-Implement straightforward TODOs safely.
+Implement tasks referenced by TODO comments.
 
 **Usage**:
 ```
 /fix-todos
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Search for TODO comments in the code.
+- For each TODO, implement the described fix or feature.
+- Remove or update the TODO comment once resolved.
+- Run tests or linters to verify correctness.

--- a/docs/commands/format.md
+++ b/docs/commands/format.md
@@ -1,11 +1,14 @@
-
 # /format
 
-Detect & run project formatter(s).
+Apply code formatting standards.
 
 **Usage**:
 ```
 /format
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Run the project's formatter (e.g., Prettier, Black, gofmt) across modified files.
+- Ensure the formatting tool uses repository configuration if available.
+- Do not introduce functional changes.
+- Summarize files that were reformatted.

--- a/docs/commands/implement.md
+++ b/docs/commands/implement.md
@@ -1,11 +1,14 @@
-
 # /implement
 
-Import/adapt code with validation.
+Develop features or fixes described in the issue or prompt.
 
 **Usage**:
 ```
 /implement
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Understand the requested feature or bug fix before coding.
+- Modify or create files to address the requirement.
+- Keep changes focused and aligned with project style.
+- Include tests or documentation updates when necessary.

--- a/docs/commands/make-it-pretty.md
+++ b/docs/commands/make-it-pretty.md
@@ -1,11 +1,14 @@
-
 # /make-it-pretty
 
-Improve readability without behavior change.
+Improve readability and style without changing behavior.
 
 **Usage**:
 ```
 /make-it-pretty
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Clean up naming, spacing, and minor style issues.
+- Simplify expressions or control flow where possible.
+- Ensure code remains functionally equivalent.
+- Highlight aesthetic changes in the summary.

--- a/docs/commands/predict-issues.md
+++ b/docs/commands/predict-issues.md
@@ -1,11 +1,14 @@
-
 # /predict-issues
 
-Predict risks, estimate timeline impact.
+Analyze code to anticipate potential problems.
 
 **Usage**:
 ```
 /predict-issues
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Examine recent changes or targeted files for logical or stylistic flaws.
+- Describe potential bugs, performance concerns, or maintainability issues.
+- Reference specific lines or functions when possible.
+- Suggest mitigations or next steps.

--- a/docs/commands/refactor.md
+++ b/docs/commands/refactor.md
@@ -1,11 +1,14 @@
-
 # /refactor
 
-Restructure code with validation & mapping.
+Improve code structure without altering behavior.
 
 **Usage**:
 ```
 /refactor
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Identify code that is hard to understand or maintain.
+- Break down large functions, rename variables, or reorganize modules as needed.
+- Ensure existing tests continue to pass.
+- Summarize the refactoring rationale.

--- a/docs/commands/remove-comments.md
+++ b/docs/commands/remove-comments.md
@@ -1,11 +1,14 @@
-
 # /remove-comments
 
-Remove obvious noise, keep valuable docs.
+Strip obsolete or commented-out code.
 
 **Usage**:
 ```
 /remove-comments
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Find comments that no longer add value or blocks of commented-out code.
+- Remove them while preserving meaningful documentation.
+- Ensure code still compiles or runs.
+- Summarize the files cleaned up.

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -1,11 +1,14 @@
-
 # /review
 
-Multi-angle code review (quality, arch, perf, sec).
+Provide a code review of recent changes.
 
 **Usage**:
 ```
 /review
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Examine the diff or specified files carefully.
+- Note strengths, potential issues, and opportunities for improvement.
+- Reference lines or functions when making comments.
+- Offer concise, actionable feedback.

--- a/docs/commands/scaffold.md
+++ b/docs/commands/scaffold.md
@@ -1,4 +1,3 @@
-
 # /scaffold
 
 Scaffold features from detected patterns.
@@ -8,4 +7,8 @@ Scaffold features from detected patterns.
 /scaffold
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Identify patterns or templates relevant to the requested feature.
+- Generate boilerplate code or file structures following those patterns.
+- Ensure generated code compiles and includes placeholders for implementation.
+- Summarize the scaffolding created.

--- a/docs/commands/security-scan.md
+++ b/docs/commands/security-scan.md
@@ -1,11 +1,14 @@
-
 # /security-scan
 
-Vulnerability & risk scan + remediation.
+Scan the project for security vulnerabilities.
 
 **Usage**:
 ```
 /security-scan
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Run any available security tools (e.g., `npm audit`, `pip audit`).
+- Inspect code for common security pitfalls.
+- Report discovered vulnerabilities with affected packages or lines.
+- Suggest mitigation steps where possible.

--- a/docs/commands/session-end.md
+++ b/docs/commands/session-end.md
@@ -1,11 +1,14 @@
-
 # /session-end
 
-Summarize progress; next steps; diffs.
+Wrap up a development session and outline next steps.
 
 **Usage**:
 ```
 /session-end
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Ensure all changes are committed or documented before finishing.
+- Summarize work completed during the session.
+- Note any remaining tasks or follow-up items.
+- Confirm the repository is in a clean state.

--- a/docs/commands/session-start.md
+++ b/docs/commands/session-start.md
@@ -1,11 +1,14 @@
-
 # /session-start
 
-Start structured work session; set goals.
+Begin a development session with an initial assessment.
 
 **Usage**:
 ```
 /session-start
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Review repository status and outstanding issues.
+- Identify the tasks to be tackled in this session.
+- Verify the environment is set up correctly.
+- Provide a brief plan of action.

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -1,11 +1,14 @@
-
 # /test
 
-Run tests; summarize failures; propose fixes.
+Run project tests to verify behavior.
 
 **Usage**:
 ```
 /test
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Execute the project's test suite using the appropriate command.
+- Capture and report the results, including failures or errors.
+- Do not modify code except to fix failing tests when instructed.
+- Summarize overall test status.

--- a/docs/commands/todos-to-issues.md
+++ b/docs/commands/todos-to-issues.md
@@ -1,11 +1,14 @@
-
 # /todos-to-issues
 
-Convert TODOs into GitHub issues.
+Convert TODO comments into issue descriptions.
 
 **Usage**:
 ```
 /todos-to-issues
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Find TODO comments throughout the codebase.
+- For each TODO, draft an issue title and summary.
+- Compile them into a list for future tracking.
+- Remove or reference TODOs to the created issues if appropriate.

--- a/docs/commands/understand.md
+++ b/docs/commands/understand.md
@@ -1,11 +1,14 @@
-
 # /understand
 
-Build mental model of project & architecture.
+Analyze code to clarify its purpose and flow.
 
 **Usage**:
 ```
 /understand
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Read the specified files or functions carefully.
+- Summarize their responsibilities and how they interact.
+- Note any surprising behaviors or dependencies.
+- Provide explanations in clear, concise language.

--- a/docs/commands/undo.md
+++ b/docs/commands/undo.md
@@ -1,11 +1,14 @@
-
 # /undo
 
-Safe rollback via git checkpoint.
+Revert recent changes safely.
 
 **Usage**:
 ```
 /undo
 ```
 
-This command keeps Gemini on task and provides concise yet informative updates.
+**Instructions:**
+- Identify the commit or file changes to revert.
+- Use git commands such as `git revert` or `git checkout` to undo them.
+- Ensure the working tree matches the desired state afterward.
+- Document what was reverted and why.


### PR DESCRIPTION
## Summary
- expand command docs with agent-focused instructions

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c377d86483209c0a59a05470d945